### PR TITLE
Adding text about non-discrimination

### DIFF
--- a/01who_we_are/02values.md
+++ b/01who_we_are/02values.md
@@ -57,9 +57,7 @@ Some examples of this value in action are:
 
 **Empower people**
 
-We strive to create a space that empowers everyone. We encourage growth and exploration, with a culture of sharing and support for change. We give people the power to make choices about how to meet their needs and to change things about our company. We share as we learn, both with technology and business, to encourage others and assist with the lessons we’ve learned. 
-
-We do not show favoritism nor do we fail to provide opportunities internally (or in our hiring decisions) based on an employee's, contractor's, or potential hire's race, color, religion, national origin/ancestry, sex, gender, LGBTQIA status, age, physicial or mental disability, veteran status, genetic information, pregnancy status, marital status, makeup of their household, or whether or not they have children.
+We strive to create a space that empowers everyone. We encourage growth and exploration, with a culture of sharing and support for change. We give people the power to make choices about how to meet their needs and to change things about our company. We share as we learn, both with technology and business, to encourage others and assist with the lessons we’ve learned. We strive to ensure that opportunites for growth are provided equitably. (See also our committment to [diversity and inclusion](https://github.com/OsioLabs/emphandbook/blob/master/04emp_conduct/02diversity.md).)
 
 Some examples of this value in action are:
 

--- a/01who_we_are/02values.md
+++ b/01who_we_are/02values.md
@@ -59,6 +59,8 @@ Some examples of this value in action are:
 
 We strive to create a space that empowers everyone. We encourage growth and exploration, with a culture of sharing and support for change. We give people the power to make choices about how to meet their needs and to change things about our company. We share as we learn, both with technology and business, to encourage others and assist with the lessons we’ve learned. 
 
+We do not show favoritism nor do we fail to provide opportunities internally (or in our hiring decisions) based on an employee's, contractor's, or potential hire's race, color, religion, national origin/ancestry, sex, gender, LGBTQIA status, age, physicial or mental disability, veteran status, genetic information, pregnancy status, marital status, makeup of their household, or whether or not they have children.
+
 Some examples of this value in action are:
 
 - In addition to technical training information we encourage people to understand and use the wider array of tools that the open source community provides. 


### PR DESCRIPTION
I think it's important to be explicit in our core values that we do not discriminate as we empower our team members with opportunities for growth. I feel this is assumed by all of us and in practice, and it should be explicitly stated somewhere in our values. I think often workplaces find excuses or put up barriers for people based on various things. Some of these things are protected classes in the United States of America, and some are common excuses for actively preventing someone from growing or being promoted within the company. I think we are a very flexible and empowering company and even though this is a negative statement (as in what we do NOT do), I think it's important to state clearly in our core values.

Not sure about the precise wording in certain cases and I welcome edits and discussion about this proposed change.